### PR TITLE
トークン未指定のときは、事前に弾くようにする

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -17,6 +17,9 @@ var listCmd = &cobra.Command{
 	Long:  "Listing apps\n\nREMARK: handling hasMore/nextKey is not supported yet :(",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if viper.GetString("api_token") == "" {
+			return errors.New("no api token specified")
+		}
 		client := appetize.Client{
 			ApiToken: viper.GetString("api_token"),
 		}

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -16,6 +16,9 @@ var showCmd = &cobra.Command{
 	Short: "Retrieve information for a single app",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if viper.GetString("api_token") == "" {
+			return errors.New("no api token specified")
+		}
 		client := appetize.Client{
 			ApiToken: viper.GetString("api_token"),
 		}

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -17,6 +17,9 @@ var uploadCmd = &cobra.Command{
 	Use:   "upload",
 	Short: "Direct file uploads",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if viper.GetString("api_token") == "" {
+			return errors.New("no api token specified")
+		}
 		client := appetize.Client{
 			ApiToken: viper.GetString("api_token"),
 		}


### PR DESCRIPTION
トークン未指定時に、いままではそのままリクエストして

```
Error: failed to list apps: failed to parse response: invalid character 'I' looking for beginning of value
```

（INVALID REQUESTの頭文字？）が出てた。

けど、意味不明なので、事前にトークンエラーで弾くようにする