### PR TITLE
github.com/inconshreveable/mousetrap が無くてWindowsビルドが通らなかったのを修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,13 @@ jobs:
             go get github.com/spf13/cobra
             go get github.com/spf13/viper
       - run:
-          name: Install tools
+          name: Install gox
           command: |
             go get -u github.com/mitchellh/gox
+            go get -u github.com/inconshreveable/mousetrap
+      - run:
+          name: Install ghr
+          command: |
             go get -u github.com/tcnksm/ghr
       - run:
           name: Build


### PR DESCRIPTION
```
2 errors occurred:
--> windows/amd64 error: exit status 1
Stderr: ../../spf13/cobra/command_win.go:9:2: cannot find package "github.com/inconshreveable/mousetrap" in any of:
	/usr/local/go/src/github.com/inconshreveable/mousetrap (from $GOROOT)
	/go/src/github.com/inconshreveable/mousetrap (from $GOPATH)

--> windows/386 error: exit status 1
Stderr: ../../spf13/cobra/command_win.go:9:2: cannot find package "github.com/inconshreveable/mousetrap" in any of:
	/usr/local/go/src/github.com/inconshreveable/mousetrap (from $GOROOT)
	/go/src/github.com/inconshreveable/mousetrap (from $GOPATH)

Exited with code 1
```

https://circleci.com/gh/YusukeIwaki/appetize-cli/59

の修正